### PR TITLE
Update .gitignore and enhance Jest test scripts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -42,3 +42,6 @@ package-lock.json
 
 # env
 .env
+
+# prisma
+./prisma/generated

--- a/package.json
+++ b/package.json
@@ -10,7 +10,9 @@
     "tauri": "tauri",
     "next-start": "cross-env BROWSER=none next dev",
     "next-build": "next build",
-    "test": "jest --passWithNoTests"
+    "test:noTest": "jest --passWithNoTests",
+    "test:coverage": "jest --coverage",
+    "test:watch": "jest --watch"
   },
   "dependencies": {
     "@apollo/server": "^4.11.3",


### PR DESCRIPTION
Update the `.gitignore` file to exclude Prisma generated files and add new Jest test scripts for coverage and watch modes to improve testing capabilities.