### PR TITLE
Add global PrismaClient instances for Postgres and MongoDB

### DIFF
--- a/global.d.ts
+++ b/global.d.ts
@@ -1,0 +1,9 @@
+import { PrismaClient as PostgresClient } from '@/../prisma/generated/postgresql';
+import { PrismaClient as MongoClient } from '@/../prisma/generated/mongo';
+
+declare global {
+  var prismaPostgres: PostgresClient | undefined;
+  var prismaMongo: MongoClient | undefined;
+}
+
+export { };

--- a/jest.setup.ts
+++ b/jest.setup.ts
@@ -1,12 +1,18 @@
-import prisma from "@/lib/prisma";
+import { PrismaClient as PostgresClient } from '@/../prisma/generated/postgresql';
+import { PrismaClient as MongoClient } from '@/../prisma/generated/mongo';
 
-// Before running tests, clean up the test database
+const prismaPostgres = new PostgresClient();
+const prismaMongo = new MongoClient();
+
+global.prismaPostgres = prismaPostgres;
+global.prismaMongo = prismaMongo;
+
 beforeAll(async () => {
-  await prisma.user.deleteMany();
-  await prisma.post.deleteMany();
-  await prisma.review.deleteMany();
+  await prismaPostgres.$connect();
+  await prismaMongo.$connect();
 });
 
 afterAll(async () => {
-  await prisma.$disconnect();
+  await prismaPostgres.$disconnect();
+  await prismaMongo.$disconnect();
 });


### PR DESCRIPTION
Introduce global instances of PrismaClient for both Postgres and MongoDB to streamline database connections in the application. Update test setup to utilize these global instances for connecting and disconnecting during tests.