### PR TITLE
fix(api): update review PUT endpoint to use consistent parameter naming

### DIFF
--- a/src/app/api/SocialButterfly/reviews/[id]/route.ts
+++ b/src/app/api/SocialButterfly/reviews/[id]/route.ts
@@ -5,7 +5,7 @@ import { PrismaClient as PostgresqlClient } from '@/../prisma/generated/postgres
 const prisma = new PostgresqlClient()
 
 // GET - Get review by ID
-export async function PUT(req: NextRequest, { params }: { params: { review_id: string } }) {
+export async function PUT(req: NextRequest, { params }: { params: { id: string } }) {
   try {
     const body = await req.json()
     const { rating, comment } = body
@@ -15,7 +15,7 @@ export async function PUT(req: NextRequest, { params }: { params: { review_id: s
     }
 
     const updated = await prisma.reviewSocialButterfly.update({
-      where: { id: params.review_id },
+      where: { id: params.id },
       data: {
         rating,
         comment,


### PR DESCRIPTION
### **PR Type**
Bug fix


___

### **Description**
- Updated `PUT` endpoint to use consistent parameter naming.

- Replaced `review_id` with `id` in function parameters and database query.

- Ensured proper error handling for missing `rating` or `comment`.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>route.ts</strong><dd><code>Standardized parameter naming in review PUT endpoint</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/app/api/SocialButterfly/reviews/[id]/route.ts

<li>Changed parameter name from <code>review_id</code> to <code>id</code> for consistency.<br> <li> Updated database query to use the new parameter name.<br> <li> Retained error handling for missing <code>rating</code> or <code>comment</code>.


</details>


  </td>
  <td><a href="https://github.com/zyx-0314/Demo-Skills/pull/37/files#diff-b4bc8980eca4110117002795731e4ab5a36fa10d7c064e5740a675e4b199b928">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>