### PR TITLE
Update admin ID retrieval in POST request

### DIFF
--- a/src/app/api/SocialButterfly/admin/events/[id]/validate/route.ts
+++ b/src/app/api/SocialButterfly/admin/events/[id]/validate/route.ts
@@ -5,7 +5,7 @@ const prisma = new PostgresqlClient()
 
 export async function POST(req: NextRequest, { params }: { params: { id: string } }) {
   try {
-    const adminId = req.headers.get('adminId')
+    const adminId = await req.json().then((data) => data.adminId)
     if (!adminId) {
       return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
     }


### PR DESCRIPTION
Retrieve the admin ID from the request body instead of the headers in the POST request.